### PR TITLE
Include README.md in packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
-python:
-    - 2.7
-    - 3.4
-    - pypy
-script: ./run-tests.sh
+install:
+    - pip install tox
+script:
+    - tox
+env:
+    - TOXENV=py27
+    - TOXENV=py34
+    - TOXENV=pypy
+    - TOXENV=packaging

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst NOTICE.txt ChangeLog *.sh
+include README.md NOTICE.txt ChangeLog *.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,10 @@
 include README.md NOTICE.txt ChangeLog *.sh
+include Makefile
+include t
+include tox.ini
+
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
+recursive-include tests *.avro
+recursive-include tests *.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-envlist = py27,py34,pypy
+envlist = py27,py34,pypy,packaging
 
 [testenv]
-deps = 
-    nose 
+deps =
+    nose
     flake8
 commands = ./run-tests.sh
+
+[testenv:packaging]
+skip_install = true
+deps =
+    check-manifest
+commands =
+    check-manifest


### PR DESCRIPTION
Without README.md, `pip install fastavro==0.8.2` fails:

```
Collecting fastavro>=0.7.8 (from internal-package==2.2.0->-r /tmp/requirements.txt (line 2))
  Downloading fastavro-0.8.2.tar.gz (167kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-e7z6XB/fastavro/setup.py", line 75, in <module>
        long_description=open('README.md').read(),
    IOError: [Errno 2] No such file or directory: 'README.md'
```